### PR TITLE
Spelling monirot->monitor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below the list of CloudFlare IP addresses is the following caveat:
 
 > NB: That list of prefixes needs to be updated regularly
 
-It's unclear what the frequency of "regularly" is, but clearly we need to monirot this list for updates. If we need to monitor this list for updates, then we may as well assign that task to a robot. If the robot is monitoring the list, then it may as well be responsible for updating the nginx configuration too. Here's a script to do just that.
+It's unclear what the frequency of "regularly" is, but clearly we need to monitor this list for updates. If we need to monitor this list for updates, then we may as well assign that task to a robot. If the robot is monitoring the list, then it may as well be responsible for updating the nginx configuration too. Here's a script to do just that.
 
 ## How it works
 


### PR DESCRIPTION
Fix spelling of "monitor" in README. I should not be allowed near a computer without an open dictionary.