### PR TITLE
Be more robust about checking VERBOSE value

### DIFF
--- a/hydrate-ips.sh
+++ b/hydrate-ips.sh
@@ -14,7 +14,7 @@ function showusage {
 # Convenience function to log and/or output to stdout
 function logput {
   /usr/bin/logger "${1}" --id --tag "${MYNAME}"
-  if [ $VERBOSE -eq 1 ]; then
+  if [ -n "$VERBOSE" ]; then
     echo "${MYNAME}[${$}]: ${1}"
   fi
 }


### PR DESCRIPTION
Leaving `VERBOSE` as undefined causes these intermittent errors:

```
/usr/local/sbin/hydrate-ips.sh: line 17: [: -eq: unary operator expected
```

This is because the `-eq` operator expects a number, which is hard to evaluate if `VERBOSE` is undefined. We could fix this by pre-defining `export VERBOSE=0` but it feels like the wrong approach; ultimately we want to know if `VERBOSE` is set, not what it is set to. Therefore we'll use the `-n` operator instead, which evaluates true for a non-null value.